### PR TITLE
Enhance dashboard UI using shadcn-style components

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,12 +12,17 @@
         "@toast-ui/editor": "^3.2.2",
         "@toast-ui/editor-plugin-color-syntax": "^3.1.0",
         "axios": "^1.9.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "marked": "^15.0.12",
+        "reka-ui": "^2.2.1",
+        "tailwind-merge": "^3.3.0",
         "tailwindcss": "^4.1.7",
         "vue": "^3.5.13",
         "vue-router": "^4.5.1"
       },
       "devDependencies": {
+        "@types/node": "^20.11.19",
         "@vitejs/plugin-vue": "^5.2.3",
         "@vue/tsconfig": "^0.7.0",
         "typescript": "~5.8.3",
@@ -484,6 +489,86 @@
         "node": ">=18"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.1.tgz",
+      "integrity": "sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.1",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
+    },
+    "node_modules/@floating-ui/vue": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.1.6.tgz",
+      "integrity": "sha512-XFlUzGHGv12zbgHNk5FN2mUB7ROul3oG2ENdTpWdE+qMFxyNxWSRmsoyhiEnpmabNm6WnUvR1OvJfUfN4ojC1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@floating-ui/utils": "^0.2.9",
+        "vue-demi": ">=0.13.0"
+      }
+    },
+    "node_modules/@floating-ui/vue/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.2.tgz",
+      "integrity": "sha512-/wENk7CbvLbkUvX1tu0mwq49CVkkWpkXubGel6birjRPyo6uQ4nQpnq5xZu823zRCwwn82zgHrvgF1vZyvmVgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.3.tgz",
+      "integrity": "sha512-p+Zh1sb6EfrfVaS86jlHGQ9HA66fJhV9x5LiE5vCbZtXEHAuhcmUZUdZ4WrFpUBfNalr2OkAJI5AcKEQF+Lebw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -804,6 +889,15 @@
         "win32"
       ]
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.7.tgz",
@@ -1066,6 +1160,32 @@
         "vite": "^5.2.0 || ^6"
       }
     },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.9.tgz",
+      "integrity": "sha512-3jztt0jpaoJO5TARe2WIHC1UQC3VMLAFUW5mmMo0yrkwtDB2AQP0+sh10BVUpWrnvHjSLvzFizydtEGLCJKFoQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-virtual": {
+      "version": "3.13.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.9.tgz",
+      "integrity": "sha512-HsvHaOo+o52cVcPhomKDZ3CMpTF/B2qg+BhPHIQJwzn4VIqDyt/rRVqtIomG6jE83IFsE2vlr6cmx7h3dHA0SA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.0.0"
+      }
+    },
     "node_modules/@toast-ui/editor": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@toast-ui/editor/-/editor-3.2.2.tgz",
@@ -1093,6 +1213,22 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
+      "integrity": "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -1299,12 +1435,60 @@
         }
       }
     },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/alien-signals": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
       "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1362,6 +1546,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1385,6 +1590,12 @@
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
       "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -2080,6 +2291,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "license": "MIT"
+    },
     "node_modules/orderedmap": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
@@ -2219,6 +2436,27 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/reka-ui": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.3.1.tgz",
+      "integrity": "sha512-2SjGeybd7jvD8EQUkzjgg7GdOQdf4cTwdVMq/lDNTMqneUFNnryGO43dg8WaM/jaG9QpSCZBvstfBFWlDdb2Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.13",
+        "@floating-ui/vue": "^1.1.6",
+        "@internationalized/date": "^3.5.0",
+        "@internationalized/number": "^3.5.0",
+        "@tanstack/vue-virtual": "^3.12.0",
+        "@vueuse/core": "^12.5.0",
+        "@vueuse/shared": "^12.5.0",
+        "aria-hidden": "^1.2.4",
+        "defu": "^6.1.4",
+        "ohash": "^2.0.11"
+      },
+      "peerDependencies": {
+        "vue": ">= 3.2.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.40.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.2.tgz",
@@ -2272,6 +2510,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.0.tgz",
+      "integrity": "sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.7.tgz",
@@ -2320,6 +2568,12 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tui-color-picker": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/tui-color-picker/-/tui-color-picker-2.2.8.tgz",
@@ -2338,6 +2592,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.3.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,6 +14,10 @@
     "@toast-ui/editor-plugin-color-syntax": "^3.1.0",
     "axios": "^1.9.0",
     "marked": "^15.0.12",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "reka-ui": "^2.2.1",
+    "tailwind-merge": "^3.3.0",
     "tailwindcss": "^4.1.7",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1"
@@ -23,6 +27,7 @@
     "@vue/tsconfig": "^0.7.0",
     "typescript": "~5.8.3",
     "vite": "^6.3.5",
-    "vue-tsc": "^2.2.8"
+    "vue-tsc": "^2.2.8",
+    "@types/node": "^20.11.19"
   }
 }

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1,20 +1,14 @@
 <script lang="ts" setup>
 import AuthErrorModal from './components/AuthErrorModal.vue';
+import DashboardLayout from './components/DashboardLayout.vue';
 
 const loginUrl = window.shiftConfig.loginRoute;
-const appUrl = window.shiftConfig.baseUrl;
 const appName = window.shiftConfig.appName;
 const username = window.shiftConfig.username;
 </script>
 <template>
-    <div class="flex flex-col items-center overflow-hidden bg-blue-100 p-4 md:h-screen">
-        <div class="w-full flex justify-between items-center px-4">
-            <a :href="appUrl" class="p-4 font-bold hover:text-blue-500">{{ appName }}</a>
-            <div v-if="username" class="text-sm text-gray-600">
-                Logged in as: <span class="font-semibold">{{ username }}</span>
-            </div>
-        </div>
-        <router-view></router-view>
-        <AuthErrorModal :redirect-url="loginUrl" />
-    </div>
+    <DashboardLayout :app-name="appName" :username="username">
+        <router-view />
+    </DashboardLayout>
+    <AuthErrorModal :redirect-url="loginUrl" />
 </template>

--- a/ui/src/components/CreateTask.vue
+++ b/ui/src/components/CreateTask.vue
@@ -2,6 +2,8 @@
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 import axios from '../axios-config';
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from './ui/card';
+import { Button } from './ui/button';
 
 const router = useRouter();
 const createError = ref<string | null>(null);
@@ -106,17 +108,12 @@ function cancel() {
 </script>
 
 <template>
-    <div class="mx-auto mt-12 w-full rounded-2xl bg-white p-6 shadow-lg">
-        <div class="mb-6 flex items-center justify-between">
-            <h1 class="text-2xl font-bold">Create Task</h1>
-            <button
-                class="rounded border border-gray-200 bg-gray-50 px-4 py-2 text-xs font-semibold text-gray-700 transition hover:bg-gray-100"
-                @click="cancel"
-            >
-                Cancel
-            </button>
-        </div>
-
+    <Card class="mx-auto mt-6 w-full max-w-xl">
+        <CardHeader class="flex items-center justify-between">
+            <CardTitle>Create Task</CardTitle>
+            <Button variant="outline" size="sm" @click="cancel">Cancel</Button>
+        </CardHeader>
+        <CardContent>
         <form class="space-y-3" @submit.prevent="createTask">
             <div>
                 <label class="mb-1 block text-sm font-medium">Title</label>
@@ -167,19 +164,15 @@ function cancel() {
                 </div>
             </div>
             <div v-if="createError" class="text-sm text-red-600">{{ createError }}</div>
-            <div>
-                <button :disabled="loading" class="mt-2 rounded bg-emerald-600 px-4 py-1 font-bold text-white hover:bg-emerald-700" type="submit">
+            <CardFooter class="pt-0">
+                <Button :disabled="loading" type="submit" class="mt-2">
                     {{ loading ? 'Creating...' : 'Create' }}
-                </button>
-                <button
-                    :disabled="loading"
-                    class="ml-2 rounded bg-gray-200 px-4 py-1 font-bold text-gray-600 hover:bg-gray-300"
-                    type="button"
-                    @click="cancel"
-                >
+                </Button>
+                <Button :disabled="loading" variant="secondary" class="ml-2" type="button" @click="cancel">
                     Cancel
-                </button>
-            </div>
+                </Button>
+            </CardFooter>
         </form>
-    </div>
+        </CardContent>
+    </Card>
 </template>

--- a/ui/src/components/DashboardLayout.vue
+++ b/ui/src/components/DashboardLayout.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { RouterLink, useRoute } from 'vue-router'
+
+const props = defineProps<{ appName: string; username?: string }>()
+
+const route = useRoute()
+
+function isActive(name: string) {
+  return route.name === name
+}
+</script>
+
+<template>
+  <div class="min-h-screen flex bg-muted/40">
+    <aside class="hidden md:block w-64 border-r bg-background">
+      <div class="p-4 text-xl font-bold border-b">{{ props.appName }}</div>
+      <nav class="p-4 space-y-2">
+        <RouterLink
+          :to="{ name: 'task-list' }"
+          :class="[
+            'block rounded px-3 py-2 text-sm transition-colors',
+            isActive('task-list') ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
+          ]"
+        >
+          Tasks
+        </RouterLink>
+      </nav>
+    </aside>
+    <div class="flex-1 flex flex-col">
+      <header class="border-b bg-background p-4 flex justify-between items-center">
+        <div class="md:hidden font-bold">{{ props.appName }}</div>
+        <div v-if="props.username" class="text-sm text-muted-foreground">
+          Logged in as: <span class="font-semibold">{{ props.username }}</span>
+        </div>
+      </header>
+      <main class="flex-1 overflow-auto p-4">
+        <slot />
+      </main>
+    </div>
+  </div>
+</template>

--- a/ui/src/components/EditTask.vue
+++ b/ui/src/components/EditTask.vue
@@ -5,6 +5,8 @@ import { marked } from 'marked';
 import { onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import axios from '../axios-config';
+import { Card, CardHeader, CardTitle, CardContent } from './ui/card';
+import { Button } from './ui/button';
 
 const router = useRouter();
 const route = useRoute();
@@ -503,16 +505,12 @@ onBeforeUnmount(() => {
 </style>
 
 <template>
-    <div class="flex w-full flex-1 flex-col overflow-hidden rounded bg-white p-4">
-        <div class="mb-4 flex items-center justify-between">
-            <h1 class="text-2xl font-bold">Edit Task</h1>
-            <button
-                class="rounded border border-gray-200 bg-gray-50 px-4 py-2 text-xs font-semibold text-gray-700 transition hover:bg-gray-100"
-                @click="cancel"
-            >
-                Cancel
-            </button>
-        </div>
+    <Card class="flex w-full flex-1 flex-col overflow-hidden">
+        <CardHeader class="flex items-center justify-between">
+            <CardTitle>Edit Task</CardTitle>
+            <Button variant="outline" size="sm" @click="cancel">Cancel</Button>
+        </CardHeader>
+        <CardContent class="flex-1 overflow-hidden">
 
         <div class="flex flex-1 justify-center gap-6 overflow-hidden">
             <div class="flex flex-col">
@@ -609,17 +607,12 @@ onBeforeUnmount(() => {
                         <div v-if="editError" class="text-sm text-red-600">{{ editError }}</div>
                     </div>
                     <div>
-                        <button :disabled="loading" class="mt-2 rounded bg-blue-600 px-4 py-1 font-bold text-white hover:bg-blue-700" type="submit">
+                        <Button :disabled="loading" class="mt-2" type="submit">
                             {{ loading ? 'Saving...' : 'Save' }}
-                        </button>
-                        <button
-                            :disabled="loading"
-                            class="ml-2 rounded bg-gray-200 px-4 py-1 font-bold text-gray-600 hover:bg-gray-300"
-                            type="button"
-                            @click="cancel"
-                        >
+                        </Button>
+                        <Button :disabled="loading" variant="secondary" class="ml-2" type="button" @click="cancel">
                             Cancel
-                        </button>
+                        </Button>
                     </div>
                 </form>
             </div>
@@ -739,5 +732,6 @@ onBeforeUnmount(() => {
                 </div>
             </div>
         </div>
-    </div>
+    </CardContent>
+    </Card>
 </template>

--- a/ui/src/components/TaskDetails.vue
+++ b/ui/src/components/TaskDetails.vue
@@ -2,6 +2,8 @@
 import { ref, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import axios from '../axios-config'
+import { Card, CardHeader, CardTitle, CardContent } from './ui/card'
+import { Button } from './ui/button'
 
 type Task = {
     id: number
@@ -44,33 +46,29 @@ onMounted(fetchTask)
 </script>
 
 <template>
-    <div class="max-w-xl mx-auto mt-12 p-6 bg-white rounded-2xl shadow-lg">
-        <div class="flex items-center justify-between mb-6">
-            <h1 class="text-2xl font-bold">Task Details</h1>
-            <button
-                @click="goBack"
-                class="px-4 py-2 rounded text-xs font-semibold bg-gray-50 text-gray-700 border border-gray-200 hover:bg-gray-100 transition"
-            >
-                Back to List
-            </button>
-        </div>
-
-        <div v-if="loading" class="text-gray-500 text-center py-8">Loading...</div>
-        <div v-else-if="error" class="text-red-600 text-center py-8">{{ error }}</div>
-        <div v-else-if="task" class="p-4 rounded-xl bg-gray-50 border border-gray-200">
-            <div><span class="font-semibold">Title:</span> {{ task.title }}</div>
-            <div><span class="font-semibold">Status:</span> {{ task.status }}</div>
-            <div><span class="font-semibold">Priority:</span> {{ task.priority }}</div>
-            <div class="mt-4">
-                <router-link
-                    v-if="task"
-                    :to="{ name: 'edit-task', params: { id: task.id.toString() } }"
-                    class="px-3 py-1 rounded text-xs font-semibold bg-amber-50 text-amber-700 border border-amber-200 hover:bg-amber-100 transition inline-block text-center"
-                    title="Click to edit, Ctrl+Click to open in new tab"
-                >
-                    Edit Task
-                </router-link>
+    <Card class="mx-auto mt-6 w-full max-w-xl">
+        <CardHeader class="flex items-center justify-between">
+            <CardTitle>Task Details</CardTitle>
+            <Button variant="outline" size="sm" @click="goBack">Back to List</Button>
+        </CardHeader>
+        <CardContent>
+            <div v-if="loading" class="text-gray-500 text-center py-8">Loading...</div>
+            <div v-else-if="error" class="text-red-600 text-center py-8">{{ error }}</div>
+            <div v-else-if="task" class="space-y-1">
+                <div><span class="font-semibold">Title:</span> {{ task.title }}</div>
+                <div><span class="font-semibold">Status:</span> {{ task.status }}</div>
+                <div><span class="font-semibold">Priority:</span> {{ task.priority }}</div>
+                <div class="mt-4">
+                    <router-link
+                        v-if="task"
+                        :to="{ name: 'edit-task', params: { id: task.id.toString() } }"
+                        class="px-3 py-1 rounded text-xs font-semibold bg-amber-50 text-amber-700 border border-amber-200 hover:bg-amber-100 transition inline-block text-center"
+                        title="Click to edit, Ctrl+Click to open in new tab"
+                    >
+                        Edit Task
+                    </router-link>
+                </div>
             </div>
-        </div>
-    </div>
+        </CardContent>
+    </Card>
 </template>

--- a/ui/src/components/TaskList.vue
+++ b/ui/src/components/TaskList.vue
@@ -2,6 +2,8 @@
 import { onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import axios from '../axios-config';
+import { Card, CardHeader, CardTitle, CardContent } from './ui/card';
+import { Button } from './ui/button';
 
 type Task = {
     id: number;
@@ -53,17 +55,14 @@ onMounted(fetchTasks);
 </script>
 
 <template>
-    <div class="mx-auto mt-12 w-full rounded-2xl bg-white p-6 shadow-lg">
-        <div class="mb-6 flex items-center justify-between">
-            <h1 class="text-2xl font-bold">Tasks</h1>
-            <button
-                class="rounded border border-emerald-200 bg-emerald-50 px-4 py-2 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-100"
-                @click="router.push({ name: 'create-task' })"
-            >
+    <Card class="mx-auto mt-6 w-full max-w-3xl">
+        <CardHeader class="flex items-center justify-between">
+            <CardTitle>Tasks</CardTitle>
+            <Button variant="outline" size="sm" @click="router.push({ name: 'create-task' })">
                 + Create
-            </button>
-        </div>
-
+            </Button>
+        </CardHeader>
+        <CardContent>
         <div v-if="loading" class="py-8 text-center text-gray-500">Loading...</div>
         <div v-else-if="error" class="py-8 text-center text-red-600">{{ error }}</div>
         <div v-else-if="tasks.length === 0" class="py-8 text-center text-gray-500">No tasks found</div>
@@ -99,5 +98,6 @@ onMounted(fetchTasks);
                 </button>
             </li>
         </ul>
-    </div>
+        </CardContent>
+    </Card>
 </template>

--- a/ui/src/components/ui/button/Button.vue
+++ b/ui/src/components/ui/button/Button.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { Primitive, type PrimitiveProps } from 'reka-ui'
+import { cn } from '../../../lib/utils'
+import { type ButtonVariants, buttonVariants } from '.'
+
+interface Props extends PrimitiveProps {
+  variant?: ButtonVariants['variant']
+  size?: ButtonVariants['size']
+  class?: HTMLAttributes['class']
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  as: 'button',
+})
+</script>
+
+<template>
+  <Primitive
+    data-slot="button"
+    :as="as"
+    :as-child="asChild"
+    :class="cn(buttonVariants({ variant, size }), props.class)"
+  >
+    <slot />
+  </Primitive>
+</template>

--- a/ui/src/components/ui/button/index.ts
+++ b/ui/src/components/ui/button/index.ts
@@ -1,0 +1,36 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+export { default as Button } from './Button.vue'
+
+export const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\'size-\'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline:
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+        secondary:
+          'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+        ghost:
+          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+)
+
+export type ButtonVariants = VariantProps<typeof buttonVariants>

--- a/ui/src/components/ui/card/Card.vue
+++ b/ui/src/components/ui/card/Card.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '../../../lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    data-slot="card"
+    :class="
+      cn(
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        props.class,
+      )
+    "
+  >
+    <slot />
+  </div>
+</template>

--- a/ui/src/components/ui/card/CardAction.vue
+++ b/ui/src/components/ui/card/CardAction.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '../../../lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    data-slot="card-action"
+    :class="cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', props.class)"
+  >
+    <slot />
+  </div>
+</template>

--- a/ui/src/components/ui/card/CardContent.vue
+++ b/ui/src/components/ui/card/CardContent.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '../../../lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    data-slot="card-content"
+    :class="cn('px-6', props.class)"
+  >
+    <slot />
+  </div>
+</template>

--- a/ui/src/components/ui/card/CardDescription.vue
+++ b/ui/src/components/ui/card/CardDescription.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '../../../lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <p
+    data-slot="card-description"
+    :class="cn('text-muted-foreground text-sm', props.class)"
+  >
+    <slot />
+  </p>
+</template>

--- a/ui/src/components/ui/card/CardFooter.vue
+++ b/ui/src/components/ui/card/CardFooter.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '../../../lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    data-slot="card-footer"
+    :class="cn('flex items-center px-6 [.border-t]:pt-6', props.class)"
+  >
+    <slot />
+  </div>
+</template>

--- a/ui/src/components/ui/card/CardHeader.vue
+++ b/ui/src/components/ui/card/CardHeader.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '../../../lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    data-slot="card-header"
+    :class="cn('@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6', props.class)"
+  >
+    <slot />
+  </div>
+</template>

--- a/ui/src/components/ui/card/CardTitle.vue
+++ b/ui/src/components/ui/card/CardTitle.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '../../../lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <h3
+    data-slot="card-title"
+    :class="cn('leading-none font-semibold', props.class)"
+  >
+    <slot />
+  </h3>
+</template>

--- a/ui/src/components/ui/card/index.ts
+++ b/ui/src/components/ui/card/index.ts
@@ -1,0 +1,7 @@
+export { default as Card } from './Card.vue'
+export { default as CardAction } from './CardAction.vue'
+export { default as CardContent } from './CardContent.vue'
+export { default as CardDescription } from './CardDescription.vue'
+export { default as CardFooter } from './CardFooter.vue'
+export { default as CardHeader } from './CardHeader.vue'
+export { default as CardTitle } from './CardTitle.vue'

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -1,0 +1,33 @@
+import { fontFamily } from 'tailwindcss/defaultTheme'
+
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{vue,js,ts}'],
+  theme: {
+    container: { center: true, padding: '2rem' },
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+        secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+        muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+        accent: { DEFAULT: 'hsl(var(--accent))', foreground: 'hsl(var(--accent-foreground))' },
+        card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      fontFamily: {
+        sans: ['Inter', ...fontFamily.sans],
+      },
+    },
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- add DashboardLayout component with sidebar
- integrate shadcn-like Button and Card components
- refactor task views to use new Card and Button
- include utility `cn()` and Tailwind config with shadcn tokens
- update dependencies for UI build

## Testing
- `npm install`
- `npm run build` *(fails: missing SSL certificates for Vite)*

------
https://chatgpt.com/codex/tasks/task_e_684449c82154832cab465ff05abdfa65